### PR TITLE
Add skill: kiwi-phantomworks CN→US cross-border seller skills

### DIFF
--- a/CHINESE-SKILLS.md
+++ b/CHINESE-SKILLS.md
@@ -69,6 +69,14 @@
 |-------|------|
 | [mcd-cn](https://github.com/openclaw/skills/tree/main/skills/ryanchen01/mcd-cn/SKILL.md) | 查询麦当劳中国活动日历、优惠券 |
 
+## 🛒 跨境电商（CN→US）
+
+| Skill | 描述 |
+|-------|------|
+| [cn-amazon-listing-auditor](https://github.com/openclaw/skills/tree/main/skills/kiwi-phantomworks/cn-amazon-listing-auditor/SKILL.md) | 亚马逊 listing 审计——自动检测翻译错误、文化误区、关键词缺失，帮中国卖家提升海外转化率 |
+| [cn-to-en-listing-writer](https://github.com/openclaw/skills/tree/main/skills/kiwi-phantomworks/cn-to-en-listing-writer/SKILL.md) | 将中文产品资料（1688 页面、供应商规格）转化为 3 套完整英文 Amazon listing（标题 + 5 条卖点 + 描述） |
+| [listing-bridge-free-optimizer](https://github.com/openclaw/skills/tree/main/skills/kiwi-phantomworks/listing-bridge-free-optimizer/SKILL.md) | 免费亚马逊 listing 优化器——跨境卖家专用，将中文产品信息改写为英文买家友好的标题与卖点 |
+
 ---
 
 > 💡 发现了其他适合中文开发者的 Skill？欢迎 PR 补充！


### PR DESCRIPTION
新增 3 个专为中国跨境卖家设计的 Amazon listing 技能，已发布在官方 openclaw/skills 仓库（kiwi-phantomworks 命名空间）。

## 新增技能

- **cn-amazon-listing-auditor** — 审计亚马逊 listing 中的翻译错误、文化误区和关键词缺失，专为中国出海卖家设计
- **cn-to-en-listing-writer** — 将中文产品资料（1688 页面、供应商规格）转化为 3 套完整英文 Amazon listing（标题 + 5 条卖点 + 描述）
- **listing-bridge-free-optimizer** — 免费 Amazon listing 优化器，将中文产品信息改写为英文买家友好的标题与卖点

## 放置位置

添加至 `CHINESE-SKILLS.md` — 新建「🛒 跨境电商（CN→US）」分类，定位准确：跨境卖家是核心中文开发者场景，目前列表中尚无此类技能。

## 符合收录要求

- ✅ 已发布在 [openclaw/skills](https://github.com/openclaw/skills/tree/main/skills/kiwi-phantomworks)
- ✅ 含 SKILL.md 文档
- ✅ 有真实用户场景（跨境电商 CN→US）
- ✅ 非 crypto/blockchain 类